### PR TITLE
fix generate theme colors script -> allow to use nested colors

### DIFF
--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -3,5 +3,5 @@ export const REGEX = {
   // PASSWORD - minimum: at least 8 chars, 1 small letter, 1 big letter, 1 special char, 1 number
   REGISTRATION_PASSWORD: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@#$%^&*!])[A-Za-z\d@#$%^&*!]{8,}$/,
   MIN_8_CHARS: /^.{8,}$/,
-  SPECIAL_CHAR: /.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?].*/,
+  SPECIAL_CHAR: /.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?].*/,
 } as const


### PR DESCRIPTION
# Description

Allow to use nested colors. For example if color link not to primitives but to '1. Color modes', and again to '1 Color modes' it was not shown in colors.ts file
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Screenshot(s)

Please attach some screenshot or a movie if provided changes affects UI.

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] Add correct label to your pull request
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
